### PR TITLE
Homebrew grip install issue.

### DIFF
--- a/assimp3.rb
+++ b/assimp3.rb
@@ -3,7 +3,7 @@ require 'formula'
 class Assimp3 < Formula
   homepage 'http://dart.golems.org'
   url 'http://dart.golems.org/downloads/src/assimpnew.tar.gz'
-  version 3.0
+  version '3.0'
   sha1 'f25ba482cdf16d6262617f3a7746babcdad7a78c'
 
   depends_on 'cmake' => :build

--- a/tinyxml.rb
+++ b/tinyxml.rb
@@ -3,7 +3,7 @@ require 'formula'
 class Tinyxml < Formula
   homepage 'http://dart.golems.org'
   url 'http://dart.golems.org/downloads/src/tinyxml.tar.gz'
-  version 1.0
+  version '1.0'
   sha1 'f2b98ca0fe0d73818a19ada79bbd5d3e1a317102'
 
   depends_on 'cmake' => :build

--- a/tinyxml2.rb
+++ b/tinyxml2.rb
@@ -3,7 +3,7 @@ require 'formula'
 class Tinyxml2 < Formula
   homepage 'http://dart.golems.org'
   url 'http://dart.golems.org/downloads/src/tinyxmlnew.tar.gz'
-  version 2.0
+  version '2.0'
   sha1 'fb4a0bcb1dc9ac8a895f2661414fb2d6da95da81'
 
   depends_on 'cmake' => :build


### PR DESCRIPTION
... that versions are strings.  This was preventing the installation of grip.

Error: Failed to import: tinyxml
version '1.0' should be a string
Error: Failed to import: tinyxml2
version '2.0' should be a string
