### PR TITLE
Update OS X image names of Travis-CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,13 +4,13 @@ matrix:
   include:
     - env: OSX=10.11
       os: osx
-      osx_image: osx10.11
+      osx_image: xcode7.3
     - env: OSX=10.10
       os: osx
-      osx_image: xcode7.1
+      osx_image: xcode7
     - env: OSX=10.9
       os: osx
-      osx_image: beta-xcode6.2
+      osx_image: beta-xcode6.1
 
 before_install:
   - brew update > /dev/null || brew update > /dev/null


### PR DESCRIPTION
This PR updates the OS X image names according to [the recent renaming of the OS X images](https://docs.travis-ci.com/user/languages/objective-c/#Supported-Xcode-versions), and decreases one degree of the Xcode versions from the latest ones supported by the each OS X versions.