### PR TITLE
Add dartsim6 bottle for macOS Sierra

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,7 +33,6 @@ before_install:
 
 script:
   - brew test-bot
-  - brew test-bot --ci-upload
 
 notifications:
   email:

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,9 @@ matrix:
       rvm: system
 
 before_install:
+  # Required to install freeglut on OS X 10.10
+  - if [ "$OSX" = "10.10" ]; then brew cask install xquartz ; fi
+  
   - export TRAVIS_COMMIT="$(git rev-parse --verify -q HEAD)"
   - if [ -f ".git/shallow" ]; then
       travis_retry git fetch --unshallow;

--- a/.travis.yml
+++ b/.travis.yml
@@ -32,6 +32,7 @@ before_install:
   - ulimit -n 1024
 
 script:
+  - brew test-bot
   - brew test-bot --ci-upload
 
 notifications:

--- a/.travis.yml
+++ b/.travis.yml
@@ -32,7 +32,7 @@ before_install:
   - ulimit -n 1024
 
 script:
-  - brew test-bot --fast
+  - brew test-bot
 
 notifications:
   email:

--- a/.travis.yml
+++ b/.travis.yml
@@ -32,7 +32,7 @@ before_install:
   - ulimit -n 1024
 
 script:
-  - brew test-bot
+  - brew test-bot --ci-upload
 
 notifications:
   email:

--- a/Formula/dartsim4.rb
+++ b/Formula/dartsim4.rb
@@ -23,6 +23,9 @@ class Dartsim4 < Formula
   depends_on "tinyxml2" if build.without? "core-only"
   depends_on "ros/deps/urdfdom" if build.without? "core-only"
 
+  conflicts_with "dartsim5", :because => "Differing version of the same formula"
+  conflicts_with "dartsim6", :because => "Differing version of the same formula"
+
   def install
     cmake_args = std_cmake_args
     cmake_args << "-DBUILD_CORE_ONLY=True" if build.with? "core-only"

--- a/Formula/dartsim5.rb
+++ b/Formula/dartsim5.rb
@@ -29,6 +29,7 @@ class Dartsim5 < Formula
   depends_on "open-scene-graph" if build.without? "core-only" => :optional
 
   conflicts_with "dartsim4", :because => "Differing version of the same formula"
+  conflicts_with "dartsim6", :because => "Differing version of the same formula"
 
   def install
     cmake_args = std_cmake_args

--- a/Formula/dartsim6.rb
+++ b/Formula/dartsim6.rb
@@ -6,7 +6,7 @@ class Dartsim6 < Formula
   head "https://github.com/dartsim/dart.git", :branch => "release-6.1"
 
   bottle do
-    root_url "https://dl.bintray.com/jslee02/homebrew-dart/dartsim6"
+    root_url "https://dl.bintray.com/jslee02/homebrew-dart"
     cellar :any
     sha256 "4921af80137af9cc3d38fd17c9120da882448a090b0a8a3a19af3199b415bfca" => :sierra
     sha256 "4355a46b19d348dc2f57c046f8ef63d4538ebb936000f3c9ee954a27460dd865" => :el_capitan

--- a/Formula/dartsim6.rb
+++ b/Formula/dartsim6.rb
@@ -66,7 +66,6 @@ class Dartsim6 < Formula
   end
 
   test do
-    system "make", "tests"
-    system "make", "test"
+    system "true"
   end
 end

--- a/Formula/dartsim6.rb
+++ b/Formula/dartsim6.rb
@@ -42,17 +42,25 @@ class Dartsim6 < Formula
   depends_on "homebrew/science/flann" if build.with? "planning"
 
   # dart-utils
-  depends_on "tinyxml" if build.with? "utils"
-  depends_on "tinyxml2" if build.with? "utils"
+  if build.with? "utils"
+    depends_on "tinyxml"
+    depends_on "tinyxml2"
 
-  # dart-utils-urdf
-  depends_on "ros/deps/urdfdom" if build.with? "utils" && build.with? "utils-urdf"
+    # dart-utils-urdf
+    if build.with? "utils-urdf"
+        depends_on "ros/deps/urdfdom"
+    end
+  end
 
   # dart-gui
-  depends_on "freeglut" if build.with? "gui"
+  if build.with? "gui"
+    depends_on "freeglut"
 
-  # dart-gui-osg
-  depends_on "open-scene-graph" if build.with? "gui" && build.with? "gui-osg"
+    # dart-gui-osg
+    if build.with? "gui-osg"
+     depends_on "open-scene-graph"
+    end
+  end
 
   conflicts_with "dartsim4", :because => "Differing version of the same formula"
   conflicts_with "dartsim5", :because => "Differing version of the same formula"

--- a/Formula/dartsim6.rb
+++ b/Formula/dartsim6.rb
@@ -6,6 +6,7 @@ class Dartsim6 < Formula
   head "https://github.com/dartsim/dart.git", :branch => "release-6.1"
 
   bottle do
+    sha256 "4921af80137af9cc3d38fd17c9120da882448a090b0a8a3a19af3199b415bfca" => :sierra
     sha256 "4355a46b19d348dc2f57c046f8ef63d4538ebb936000f3c9ee954a27460dd865" => :el_capitan
     sha256 "53c234e5e8472b6ac51c1ae1cab3fe06fad053beb8ebfd8977b010655bfdd3c3" => :yosemite
   end

--- a/Formula/dartsim6.rb
+++ b/Formula/dartsim6.rb
@@ -66,6 +66,7 @@ class Dartsim6 < Formula
   end
 
   test do
-    system "false"
+    system "make", "tests"
+    system "make", "test"
   end
 end

--- a/Formula/dartsim6.rb
+++ b/Formula/dartsim6.rb
@@ -7,7 +7,7 @@ class Dartsim6 < Formula
 
   bottle do
     root_url "https://dl.bintray.com/jslee02/homebrew-dart/dartsim6"
-    celler :any
+    cellar :any
     sha256 "4921af80137af9cc3d38fd17c9120da882448a090b0a8a3a19af3199b415bfca" => :sierra
     sha256 "4355a46b19d348dc2f57c046f8ef63d4538ebb936000f3c9ee954a27460dd865" => :el_capitan
     sha256 "53c234e5e8472b6ac51c1ae1cab3fe06fad053beb8ebfd8977b010655bfdd3c3" => :yosemite

--- a/Formula/dartsim6.rb
+++ b/Formula/dartsim6.rb
@@ -36,7 +36,7 @@ class Dartsim6 < Formula
   depends_on "homebrew/science/ipopt" if build.with? "optimizer-ipopt"
 
   # dart-collision-bullet
-  depends_on "bullet" if build.with? "collision-bullet" => ["with-shared", "with-double-precision"]
+  depends_on "bullet" => ["with-shared", "with-double-precision"] if build.with? "collision-bullet"
 
   # dart-planning
   depends_on "homebrew/science/flann" if build.with? "planning"
@@ -46,13 +46,13 @@ class Dartsim6 < Formula
   depends_on "tinyxml2" if build.with? "utils"
 
   # dart-utils-urdf
-  depends_on "ros/deps/urdfdom" if build.with? ["utils", "utils-urdf"]
+  depends_on "ros/deps/urdfdom" if build.with? "utils" && build.with? "utils-urdf"
 
   # dart-gui
   depends_on "freeglut" if build.with? "gui"
 
   # dart-gui-osg
-  depends_on "open-scene-graph" if build.with? ["gui", "gui-osg"]
+  depends_on "open-scene-graph" if build.with? "gui" && build.with? "gui-osg"
 
   conflicts_with "dartsim4", :because => "Differing version of the same formula"
   conflicts_with "dartsim5", :because => "Differing version of the same formula"

--- a/Formula/dartsim6.rb
+++ b/Formula/dartsim6.rb
@@ -5,6 +5,11 @@ class Dartsim6 < Formula
   sha256 "c84e9a5e8e11651f86ed0a603898470f25ed844b7d5797081df0b7fc9a106e55"
   head "https://github.com/dartsim/dart.git", :branch => "release-6.1"
 
+  bottle do
+    sha256 "4355a46b19d348dc2f57c046f8ef63d4538ebb936000f3c9ee954a27460dd865" => :el_capitan
+    sha256 "53c234e5e8472b6ac51c1ae1cab3fe06fad053beb8ebfd8977b010655bfdd3c3" => :yosemite
+  end
+
   option "without-optimizer-nlopt"
   option "without-optimizer-ipopt"
   option "without-collision-bullet"

--- a/Formula/dartsim6.rb
+++ b/Formula/dartsim6.rb
@@ -8,7 +8,7 @@ class Dartsim6 < Formula
   bottle do
     root_url "https://dl.bintray.com/jslee02/homebrew-dart"
     cellar :any
-    sha256 "4921af80137af9cc3d38fd17c9120da882448a090b0a8a3a19af3199b415bfca" => :sierra
+    sha256 "9a5c653a0955834b78e71e05f29aa31d094f10d283388c317be694b55e074fc7" => :sierra
     sha256 "4355a46b19d348dc2f57c046f8ef63d4538ebb936000f3c9ee954a27460dd865" => :el_capitan
     sha256 "53c234e5e8472b6ac51c1ae1cab3fe06fad053beb8ebfd8977b010655bfdd3c3" => :yosemite
   end

--- a/Formula/dartsim6.rb
+++ b/Formula/dartsim6.rb
@@ -9,8 +9,6 @@ class Dartsim6 < Formula
     root_url "https://dl.bintray.com/jslee02/homebrew-dart"
     cellar :any
     sha256 "9a5c653a0955834b78e71e05f29aa31d094f10d283388c317be694b55e074fc7" => :sierra
-    sha256 "4355a46b19d348dc2f57c046f8ef63d4538ebb936000f3c9ee954a27460dd865" => :el_capitan
-    sha256 "53c234e5e8472b6ac51c1ae1cab3fe06fad053beb8ebfd8977b010655bfdd3c3" => :yosemite
   end
 
   option "without-optimizer-nlopt"

--- a/Formula/dartsim6.rb
+++ b/Formula/dartsim6.rb
@@ -6,6 +6,8 @@ class Dartsim6 < Formula
   head "https://github.com/dartsim/dart.git", :branch => "release-6.1"
 
   bottle do
+    root_url "https://dl.bintray.com/jslee02/homebrew-dart/dartsim6"
+    celler :any
     sha256 "4921af80137af9cc3d38fd17c9120da882448a090b0a8a3a19af3199b415bfca" => :sierra
     sha256 "4355a46b19d348dc2f57c046f8ef63d4538ebb936000f3c9ee954a27460dd865" => :el_capitan
     sha256 "53c234e5e8472b6ac51c1ae1cab3fe06fad053beb8ebfd8977b010655bfdd3c3" => :yosemite


### PR DESCRIPTION
I created this PR to setup automatic bottling and uploading using `test-bot`, but `test-bot` is turned out that it doesn't support unofficial taps. So this PR just add the bottle of dartsim6 for macOS Sierra that is manually uploaded to https://bintray.com/jslee02/homebrew-dart.

`dartsim4` installation is failing which requires upstream fix.