### PR TITLE
[dartsim6] Enable ipopt by default

### DIFF
--- a/Formula/dartsim6.rb
+++ b/Formula/dartsim6.rb
@@ -3,7 +3,6 @@ class Dartsim6 < Formula
   homepage "https://dartsim.github.io"
   url "https://github.com/dartsim/dart/archive/v6.2.0.tar.gz"
   sha256 "fac3000412280ffd3013273c91e12553bbcd9a6889916b6e95f462dde632980d"
-  revision 1
   head "https://github.com/dartsim/dart.git", :branch => "release-6.2"
 
   option "without-optimizer-nlopt"

--- a/Formula/dartsim6.rb
+++ b/Formula/dartsim6.rb
@@ -3,10 +3,11 @@ class Dartsim6 < Formula
   homepage "https://dartsim.github.io"
   url "https://github.com/dartsim/dart/archive/v6.2.0.tar.gz"
   sha256 "fac3000412280ffd3013273c91e12553bbcd9a6889916b6e95f462dde632980d"
+  revision 1
   head "https://github.com/dartsim/dart.git", :branch => "release-6.2"
 
   option "without-optimizer-nlopt"
-  option "with-optimizer-ipopt"
+  option "without-optimizer-ipopt"
   option "without-collision-bullet"
   option "without-collision-ode"
   option "without-planning"


### PR DESCRIPTION
This was disabled by #36 because one of the dependencies of `ipopt`, `mumps 5.0.2`, is broken. This PR will be merged once `mumps` becomes available.