### PR TITLE
Add tinyxml2@3 and make dartsim4 depends on it

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,21 +9,25 @@ matrix:
       osx_image: xcode8.3
       rvm: system
 
+cache:
+  directories:
+    - $HOME/.gem/ruby
+    - Library/Homebrew/vendor/bundle
+
 before_install:
   - export TRAVIS_COMMIT="$(git rev-parse --verify -q HEAD)"
   - if [ -f ".git/shallow" ]; then
       travis_retry git fetch --unshallow;
     fi
-  - sudo chown -R $USER "$(brew --repo)"
-  - git -C "$(brew --repo)" reset --hard origin/master
-  - git -C "$(brew --repo)" clean -qxdff
-  - export HOMEBREW_DEVELOPER="1"
+  - HOMEBREW_REPOSITORY="$(brew --repo)"
+  - sudo chown -R "$USER" "$HOMEBREW_REPOSITORY"
+  - git -C "$HOMEBREW_REPOSITORY" reset --hard origin/master
   - brew update || brew update
-  - rm -rf "$(brew --repo $TRAVIS_REPO_SLUG)"
-  - mkdir -p "$(brew --repo $TRAVIS_REPO_SLUG)"
-  - rsync -az "$TRAVIS_BUILD_DIR/" "$(brew --repo $TRAVIS_REPO_SLUG)"
-  - export TRAVIS_BUILD_DIR="$(brew --repo $TRAVIS_REPO_SLUG)"
-  - cd "$(brew --repo)"
+  - HOMEBREW_TAP_DIR="$(brew --repo "$TRAVIS_REPO_SLUG")"
+  - mkdir -p "$HOMEBREW_TAP_DIR"
+  - rm -rf "$HOMEBREW_TAP_DIR"
+  - ln -s "$PWD" "$HOMEBREW_TAP_DIR"
+  - export HOMEBREW_DEVELOPER="1"
   - ulimit -n 1024
 
 script:

--- a/Formula/dartsim4.rb
+++ b/Formula/dartsim4.rb
@@ -20,7 +20,7 @@ class Dartsim4 < Formula
 
   depends_on "flann" if build.without? "core-only"
   depends_on "tinyxml" if build.without? "core-only"
-  depends_on "tinyxml2@5" if build.without? "core-only"
+  depends_on "tinyxml2@3" if build.without? "core-only"
   depends_on "ros/deps/urdfdom" if build.without? "core-only"
 
   conflicts_with "dartsim5", :because => "Differing version of the same formula"

--- a/Formula/dartsim4.rb
+++ b/Formula/dartsim4.rb
@@ -20,7 +20,7 @@ class Dartsim4 < Formula
 
   depends_on "flann" if build.without? "core-only"
   depends_on "tinyxml" if build.without? "core-only"
-  depends_on "tinyxml2" if build.without? "core-only"
+  depends_on "tinyxml2@5" if build.without? "core-only"
   depends_on "ros/deps/urdfdom" if build.without? "core-only"
 
   conflicts_with "dartsim5", :because => "Differing version of the same formula"

--- a/Formula/tinyxml2@3.rb
+++ b/Formula/tinyxml2@3.rb
@@ -1,8 +1,8 @@
-class Tinyxml2AT5 < Formula
+class Tinyxml2AT3 < Formula
   desc "Improved tinyxml (in memory efficiency and size)"
   homepage "http://grinninglizard.com/tinyxml2"
-  url "https://github.com/leethomason/tinyxml2/archive/5.0.1.tar.gz"
-  sha256 "cd33f70a856b681506e3650f9f5f5e5e6c7232da7fa3cfc4e8f56fe7b77dd735"
+  url "https://github.com/leethomason/tinyxml2/archive/3.0.0.tar.gz"
+  sha256 "128aa1553e88403833e0cccf1b651f45ce87bc207871f53fdcc8e7f9ec795747"
   head "https://github.com/leethomason/tinyxml2.git"
 
   depends_on "cmake" => :build

--- a/Formula/tinyxml2@5.rb
+++ b/Formula/tinyxml2@5.rb
@@ -1,0 +1,26 @@
+class Tinyxml2AT5 < Formula
+  desc "Improved tinyxml (in memory efficiency and size)"
+  homepage "http://grinninglizard.com/tinyxml2"
+  url "https://github.com/leethomason/tinyxml2/archive/5.0.1.tar.gz"
+  sha256 "cd33f70a856b681506e3650f9f5f5e5e6c7232da7fa3cfc4e8f56fe7b77dd735"
+  head "https://github.com/leethomason/tinyxml2.git"
+
+  depends_on "cmake" => :build
+
+  def install
+    system "cmake", ".", *std_cmake_args
+    system "make", "install"
+  end
+
+  test do
+    (testpath/"test.cpp").write <<~EOS
+      #include <tinyxml2.h>
+      int main() {
+        tinyxml2::XMLDocument doc (false);
+        return 0;
+      }
+    EOS
+    system ENV.cc, "test.cpp", "-L#{lib}", "-ltinyxml2", "-o", "test"
+    system "./test"
+  end
+end


### PR DESCRIPTION
`dartsim4` is only compatible with tinyxml2 v3 but not v6 (current version in homebrew-core). This PR adds `tinyxml2@3` and makes `dartsim4` depends on it.