### PR TITLE
Add ipopt and its dependencies as homebrew-science deprecated

### DIFF
--- a/Formula/dartsim5.rb
+++ b/Formula/dartsim5.rb
@@ -25,7 +25,7 @@ class Dartsim5 < Formula
   depends_on "tinyxml2" if build.without? "core-only"
   depends_on "ros/deps/urdfdom" if build.without? "core-only"
   depends_on "nlopt" if build.without? "core-only" => :optional
-  depends_on "homebrew/science/ipopt" if build.without? "core-only" => :optional
+  depends_on "dartsim/dart/ipopt" if build.without? "core-only" => :optional
   depends_on "open-scene-graph" if build.without? "core-only" => :optional
 
   conflicts_with "dartsim4", :because => "Differing version of the same formula"

--- a/Formula/dartsim6.rb
+++ b/Formula/dartsim6.rb
@@ -28,7 +28,7 @@ class Dartsim6 < Formula
   depends_on "nlopt" if build.with? "optimizer-nlopt"
 
   # dart-optimizer-ipopt
-  depends_on "homebrew/science/ipopt" if build.with? "optimizer-ipopt"
+  depends_on "dartsim/dart/ipopt" if build.with? "optimizer-ipopt"
 
   # dart-collision-bullet
   depends_on "bullet" if build.with? "collision-bullet"

--- a/Formula/ipopt.rb
+++ b/Formula/ipopt.rb
@@ -1,0 +1,62 @@
+class Ipopt < Formula
+  desc "Large-scale nonlinear optimization package"
+  homepage "https://projects.coin-or.org/Ipopt"
+  url "https://www.coin-or.org/download/source/Ipopt/Ipopt-3.12.8.tgz"
+  sha256 "62c6de314220851b8f4d6898b9ae8cf0a8f1e96b68429be1161f8550bb7ddb03"
+  revision 1
+  head "https://projects.coin-or.org/svn/Ipopt/trunk", :using => :svn
+
+  bottle :disable, "needs to be rebuilt with latest open-mpi"
+
+  option "without-test", "Skip build-time tests (not recommended)"
+  deprecated_option "without-check" => "without-test"
+
+  depends_on "ampl-mp" => :recommended
+  depends_on "openblas" => :optional
+  depends_on "pkg-config" => :build
+
+  # IPOPT is not able to use parallel MUMPS.
+  depends_on "mumps" => ["without-mpi"] + (build.with?("openblas") ? ["with-openblas"] : [])
+
+  depends_on :fortran
+
+  def install
+    ENV.delete("MPICC")  # configure will pick these up and use them to link
+    ENV.delete("MPIFC")  # which leads to the linker crashing.
+    ENV.delete("MPICXX")
+    mumps_libs = %w[-ldmumps -lmumps_common -lpord -lmpiseq]
+    mumps_incdir = Formula["mumps"].opt_libexec/"include"
+    mumps_libcmd = "-L#{Formula["mumps"].opt_lib} " + mumps_libs.join(" ")
+
+    args = ["--disable-debug",
+            "--disable-dependency-tracking",
+            "--prefix=#{prefix}",
+            "--with-mumps-incdir=#{mumps_incdir}",
+            "--with-mumps-lib=#{mumps_libcmd}",
+            "--enable-shared",
+            "--enable-static"]
+
+    if build.with? "openblas"
+      args << "--with-blas-incdir=#{Formula["openblas"].opt_include}"
+      args << "--with-blas-lib=-L#{Formula["openblas"].opt_lib} -lopenblas"
+      args << "--with-lapack-incdir=#{Formula["openblas"].opt_include}"
+      args << "--with-lapack-lib=-L#{Formula["openblas"].opt_lib} -lopenblas"
+    end
+
+    if build.with? "ampl-mp"
+      args << "--with-asl-incdir=#{Formula["ampl-mp"].opt_include}/asl"
+      args << "--with-asl-lib=-L#{Formula["ampl-mp"].opt_lib} -lasl"
+    end
+
+    system "./configure", *args
+    system "make"
+    ENV.deparallelize # Needs a serialized install
+    system "make", "test" if build.with? "test"
+    system "make", "install"
+  end
+
+  test do
+    # IPOPT still fails to converge on the Waechter-Biegler problem?!?!
+    system "#{bin}/ipopt", "#{Formula["ampl-mp"].opt_pkgshare}/example/wb" if build.with? "ampl-mp"
+  end
+end

--- a/Formula/mumps.rb
+++ b/Formula/mumps.rb
@@ -1,0 +1,219 @@
+class Mumps < Formula
+  desc "Parallel Sparse Direct Solver"
+  homepage "http://mumps-solver.org"
+  url "http://mumps.enseeiht.fr/MUMPS_5.1.1.tar.gz"
+  mirror "http://graal.ens-lyon.fr/MUMPS/MUMPS_5.1.1.tar.gz"
+  sha256 "a2a1f89c470f2b66e9982953cbd047d429a002fab9975400cef7190d01084a06"
+  revision 1
+
+  bottle :disable, "needs to be rebuilt with latest open-mpi"
+
+  depends_on :mpi => [:cc, :cxx, :f90, :recommended]
+  depends_on "openblas" => OS.mac? ? :optional : :recommended
+  depends_on "veclibfort" if build.without?("openblas") && OS.mac?
+  depends_on :fortran
+
+  if build.with? "mpi"
+    if OS.mac?
+      depends_on "scalapack" => build.with?("openblas") ? ["with-openblas"] : []
+    else
+      depends_on "scalapack" => build.without?("openblas") ? ["without-openblas"] : []
+    end
+  end
+  depends_on "metis"    => :optional if build.without? "mpi"
+  depends_on "parmetis" => :optional if build.with? "mpi"
+  depends_on "scotch"   => :optional
+
+  resource "mumps_simple" do
+    url "https://github.com/dpo/mumps_simple/archive/v0.4.tar.gz"
+    sha256 "87d1fc87eb04cfa1cba0ca0a18f051b348a93b0b2c2e97279b23994664ee437e"
+  end
+
+  def install
+    make_args = ["RANLIB=echo"]
+    if OS.mac?
+      # Building dylibs with mpif90 causes segfaults on 10.8 and 10.10. Use gfortran.
+      shlibs_args = ["LIBEXT=.dylib",
+                     "AR=#{ENV["FC"]} -dynamiclib -Wl,-install_name -Wl,#{lib}/$(notdir $@) -undefined dynamic_lookup -o "]
+    else
+      shlibs_args = ["LIBEXT=.so",
+                     "AR=$(FL) -shared -Wl,-soname -Wl,$(notdir $@) -o "]
+    end
+    make_args += ["OPTF=-O", "CDEFS=-DAdd_"]
+    orderingsf = "-Dpord"
+
+    makefile = build.with?("mpi") ? "Makefile.G95.PAR" : "Makefile.G95.SEQ"
+    cp "Make.inc/" + makefile, "Makefile.inc"
+
+    if build.with? "scotch5"
+      make_args += ["SCOTCHDIR=#{Formula["scotch5"].opt_prefix}",
+                    "ISCOTCH=-I#{Formula["scotch5"].opt_include}"]
+
+      if build.with? "mpi"
+        scotch_libs = "LSCOTCH=-L$(SCOTCHDIR)/lib -lptesmumps -lptscotch -lptscotcherr"
+        scotch_libs += " -lptscotchparmetis" if build.with? "parmetis"
+        make_args << scotch_libs
+        orderingsf << " -Dptscotch"
+      else
+        scotch_libs = "LSCOTCH=-L$(SCOTCHDIR) -lesmumps -lscotch -lscotcherr"
+        scotch_libs += " -lscotchmetis" if build.with? "metis"
+        make_args << scotch_libs
+        orderingsf << " -Dscotch"
+      end
+    elsif build.with? "scotch"
+      make_args += ["SCOTCHDIR=#{Formula["scotch"].opt_prefix}",
+                    "ISCOTCH=-I#{Formula["scotch"].opt_include}"]
+
+      if build.with? "mpi"
+        scotch_libs = "LSCOTCH=-L$(SCOTCHDIR)/lib -lptscotch -lptscotcherr -lptscotcherrexit -lscotch"
+        scotch_libs += "-lptscotchparmetis" if build.with? "parmetis"
+        make_args << scotch_libs
+        orderingsf << " -Dptscotch"
+      else
+        scotch_libs = "LSCOTCH=-L$(SCOTCHDIR) -lscotch -lscotcherr -lscotcherrexit"
+        scotch_libs += "-lscotchmetis" if build.with? "metis"
+        make_args << scotch_libs
+        orderingsf << " -Dscotch"
+      end
+    end
+
+    if build.with? "parmetis"
+      make_args += ["LMETISDIR=#{Formula["parmetis"].opt_lib}",
+                    "IMETIS=#{Formula["parmetis"].opt_include}",
+                    "LMETIS=-L#{Formula["parmetis"].opt_lib} -lparmetis -L#{Formula["metis"].opt_lib} -lmetis"]
+      orderingsf << " -Dparmetis"
+    elsif build.with? "metis"
+      make_args += ["LMETISDIR=#{Formula["metis"].opt_lib}",
+                    "IMETIS=#{Formula["metis"].opt_include}",
+                    "LMETIS=-L#{Formula["metis"].opt_lib} -lmetis"]
+      orderingsf << " -Dmetis"
+    end
+
+    make_args << "ORDERINGSF=#{orderingsf}"
+
+    if build.with? "mpi"
+      make_args += ["CC=#{ENV["MPICC"]} -fPIC",
+                    "FC=#{ENV["MPIFC"]} -fPIC",
+                    "FL=#{ENV["MPIFC"]} -fPIC",
+                    "SCALAP=-L#{Formula["scalapack"].opt_lib} -lscalapack",
+                    "INCPAR=", # Let MPI compilers fill in the blanks.
+                    "LIBPAR=$(SCALAP)"]
+    else
+      make_args += ["CC=#{ENV["CC"]} -fPIC",
+                    "FC=#{ENV["FC"]} -fPIC",
+                    "FL=#{ENV["FC"]} -fPIC"]
+    end
+
+    if build.with? "openblas"
+      make_args << "LIBBLAS=-L#{Formula["openblas"].opt_lib} -lopenblas"
+    elsif build.with? "veclibfort"
+      make_args << "LIBBLAS=-L#{Formula["veclibfort"].opt_lib} -lvecLibFort"
+    else
+      make_args << "LIBBLAS=-lblas -llapack"
+    end
+
+    ENV.deparallelize # Build fails in parallel on Mavericks.
+
+    system "make", "alllib", *(shlibs_args + make_args)
+
+    lib.install Dir["lib/*"]
+    lib.install ("libseq/libmpiseq" + (OS.mac? ? ".dylib" : ".so")) if build.without? "mpi"
+
+    # Build static libraries (e.g., for Dolfin)
+    system "make", "alllib", *make_args
+    (libexec/"lib").install Dir["lib/*.a"]
+    (libexec/"lib").install "libseq/libmpiseq.a" if build.without? "mpi"
+
+    inreplace "examples/Makefile" do |s|
+      s.change_make_var! "libdir", lib
+    end
+
+    libexec.install "include"
+    include.install_symlink Dir[libexec/"include/*"]
+    # The following .h files may conflict with others related to MPI
+    # in /usr/local/include. Do not symlink them.
+    (libexec/"include").install Dir["libseq/*.h"] if build.without? "mpi"
+
+    doc.install Dir["doc/*.pdf"]
+    pkgshare.install "examples"
+
+    prefix.install "Makefile.inc"  # For the record.
+    File.open(prefix/"make_args.txt", "w") do |f|
+      f.puts(make_args.join(" "))  # Record options passed to make.
+    end
+
+    if build.with? "mpi"
+      resource("mumps_simple").stage do
+        simple_args = ["CC=#{ENV["MPICC"]}", "prefix=#{prefix}", "mumps_prefix=#{prefix}",
+                       "scalapack_libdir=#{Formula["scalapack"].opt_lib}"]
+        if build.with? "scotch5"
+          simple_args += ["scotch_libdir=#{Formula["scotch5"].opt_lib}",
+                          "scotch_libs=-L$(scotch_libdir) -lptesmumps -lptscotch -lptscotcherr"]
+        elsif build.with? "scotch"
+          simple_args += ["scotch_libdir=#{Formula["scotch"].opt_lib}",
+                          "scotch_libs=-L$(scotch_libdir) -lptscotch -lptscotcherr -lscotch"]
+        end
+        if build.with? "openblas"
+          simple_args += ["blas_libdir=#{Formula["openblas"].opt_lib}",
+                          "blas_libs=-L$(blas_libdir) -lopenblas"]
+        end
+        system "make", "SHELL=/bin/bash", *simple_args
+        lib.install ("libmumps_simple." + (OS.mac? ? "dylib" : "so"))
+        include.install "mumps_simple.h"
+      end
+    end
+  end
+
+  def caveats
+    s = <<-EOS.undent
+      MUMPS was built with shared libraries. If required,
+      static libraries are available in
+        #{opt_libexec}/lib
+    EOS
+    if build.without? "mpi"
+      s += <<-EOS.undent
+      You built a sequential MUMPS library.
+      Please add #{libexec}/include to the include path
+      when building software that depends on MUMPS.
+      EOS
+    end
+    s
+  end
+
+  test do
+    ENV.fortran
+    cp_r pkgshare/"examples", testpath
+    opts = ["-I#{opt_include}", "-L#{opt_lib}", "-lmumps_common", "-lpord"]
+    if Tab.for_name("mumps").with? "openblas"
+      opts << "-L#{Formula["openblas"].opt_lib}" << "-lopenblas"
+    elsif OS.mac?
+      opts << "-L#{Formula["veclibfort"].opt_lib}" << "-lvecLibFort"
+    else
+      opts << "-lblas" << "-llapack"
+    end
+    if Tab.for_name("mumps").with?("mpi")
+      f90 = "mpif90"
+      cc = "mpicc"
+      mpirun = "mpirun -np 2"
+      opts << "-lscalapack"
+    else
+      f90 = ENV["FC"]
+      cc = ENV["CC"]
+      mpirun = ""
+    end
+
+    cd testpath/"examples" do
+      system f90, "-o", "ssimpletest", "ssimpletest.F", "-lsmumps", *opts
+      system "#{mpirun} ./ssimpletest < input_simpletest_real"
+      system f90, "-o", "dsimpletest", "dsimpletest.F", "-ldmumps", *opts
+      system "#{mpirun} ./dsimpletest < input_simpletest_real"
+      system f90, "-o", "csimpletest", "csimpletest.F", "-lcmumps", *opts
+      system "#{mpirun} ./csimpletest < input_simpletest_cmplx"
+      system f90, "-o", "zsimpletest", "zsimpletest.F", "-lzmumps", *opts
+      system "#{mpirun} ./zsimpletest < input_simpletest_cmplx"
+      system cc, "-c", "c_example.c", "-I#{opt_include}"
+      system f90, "-o", "c_example", "c_example.o", "-ldmumps", *opts
+      system *(mpirun.split + ["./c_example"] + opts)
+    end
+  end
+end

--- a/Formula/parmetis.rb
+++ b/Formula/parmetis.rb
@@ -1,0 +1,75 @@
+class Parmetis < Formula
+  desc "Parallel graph partitioning and fill-reducing matrix"
+  homepage "http://glaros.dtc.umn.edu/gkhome/metis/parmetis/overview"
+  url "http://glaros.dtc.umn.edu/gkhome/fetch/sw/parmetis/parmetis-4.0.3.tar.gz"
+  sha256 "f2d9a231b7cf97f1fee6e8c9663113ebf6c240d407d3c118c55b3633d6be6e5f"
+  revision 5
+
+  bottle :disable, "needs to be rebuilt with latest open-mpi"
+
+  # METIS 5.* is required. It comes bundled with ParMETIS.
+  # We prefer to brew it ourselves.
+  depends_on "metis"
+
+  depends_on "cmake" => :build
+  depends_on :mpi => :cc
+
+  # Do not build the METIS 5.* that ships with ParMETIS.
+  patch :DATA
+
+  # Bug fixes from PETSc developers. Mirrored because the SHA-256s get
+  # invalidated every time Bitbucket updates the Git version they use.
+  patch do
+    # From: https://bitbucket.org/petsc/pkg-parmetis/commits/82409d68aa1d6cbc70740d0f35024aae17f7d5cb/raw/
+    url "https://raw.githubusercontent.com/Homebrew/patches/f104fbb1e09402798cbbc06d2f695d85398c0c89/parmetis/commit-82409d68.patch"
+    sha256 "0349f5bc19a2ba9fe9e1b9d385072dabe59262522bd7cf66f26c6bc31bbb1b86"
+  end
+
+  patch do
+    # From: https://bitbucket.org/petsc/pkg-parmetis/commits/1c1a9fd0f408dc4d42c57f5c3ee6ace411eb222b/raw/
+    url "https://raw.githubusercontent.com/Homebrew/patches/f104fbb1e09402798cbbc06d2f695d85398c0c89/parmetis/commit-1c1a9fd0.patch"
+    sha256 "baec5e1fa6bb4f6c59e3ede564485e0ad743f58c9875fd65cb715b5c14a491b5"
+  end
+
+  def install
+    ENV["LDFLAGS"] = "-L#{Formula["metis"].lib} -lmetis -lm"
+
+    system "make", "config", "prefix=#{prefix}", "shared=1"
+    system "make", "install"
+    pkgshare.install "Graphs" # Sample data for test
+  end
+
+  test do
+    system "mpirun", "-np", "4", "#{bin}/ptest", "#{pkgshare}/Graphs/rotor.graph"
+    ohai "Test results are in ~/Library/Logs/Homebrew/parmetis."
+  end
+end
+
+__END__
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index ca945dd..1bf94e9 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -33,7 +33,7 @@ include_directories(${GKLIB_PATH})
+ include_directories(${METIS_PATH}/include)
+
+ # List of directories that cmake will look for CMakeLists.txt
+-add_subdirectory(${METIS_PATH}/libmetis ${CMAKE_BINARY_DIR}/libmetis)
++#add_subdirectory(${METIS_PATH}/libmetis ${CMAKE_BINARY_DIR}/libmetis)
+ add_subdirectory(include)
+ add_subdirectory(libparmetis)
+ add_subdirectory(programs)
+
+diff --git a/libparmetis/CMakeLists.txt b/libparmetis/CMakeLists.txt
+index 9cfc8a7..dfc0125 100644
+--- a/libparmetis/CMakeLists.txt
++++ b/libparmetis/CMakeLists.txt
+@@ -5,7 +5,7 @@ file(GLOB parmetis_sources *.c)
+ # Create libparmetis
+ add_library(parmetis ${ParMETIS_LIBRARY_TYPE} ${parmetis_sources})
+ # Link with metis and MPI libraries.
+-target_link_libraries(parmetis metis ${MPI_LIBRARIES})
++target_link_libraries(parmetis metis ${MPI_LIBRARIES} "-lm")
+ set_target_properties(parmetis PROPERTIES LINK_FLAGS "${MPI_LINK_FLAGS}")
+
+ install(TARGETS parmetis

--- a/Formula/scotch.rb
+++ b/Formula/scotch.rb
@@ -1,0 +1,65 @@
+class Scotch < Formula
+  desc "Graph/mesh/hypergraph partitioning, clustering, and ordering"
+  homepage "https://gforge.inria.fr/projects/scotch"
+  url "https://gforge.inria.fr/frs/download.php/file/34618/scotch_6.0.4.tar.gz"
+  sha256 "f53f4d71a8345ba15e2dd4e102a35fd83915abf50ea73e1bf6efe1bc2b4220c7"
+  revision 5
+
+  bottle :disable, "needs to be rebuilt with latest open-mpi"
+
+  option "without-test", "skip build-time tests (not recommended)"
+  deprecated_option "without-check" => "without-test"
+
+  depends_on :mpi => :cc
+  depends_on "xz" => :optional # Provides lzma compression.
+
+  def install
+    ENV.deparallelize if MacOS.version >= :sierra
+    cd "src" do
+      ln_s "Make.inc/Makefile.inc.i686_mac_darwin10", "Makefile.inc"
+      # default CFLAGS: -O3 -Drestrict=__restrict -DCOMMON_FILE_COMPRESS_GZ -DCOMMON_PTHREAD -DCOMMON_PTHREAD_BARRIER
+      #                 -DCOMMON_RANDOM_FIXED_SEED -DCOMMON_TIMING_OLD -DSCOTCH_PTHREAD -DSCOTCH_RENAME
+      # MPI implementation is not threadsafe, do not use DSCOTCH_PTHREAD
+
+      cflags   = %w[-O3 -fPIC -Drestrict=__restrict -DCOMMON_PTHREAD_BARRIER
+                    -DCOMMON_PTHREAD
+                    -DSCOTCH_CHECK_AUTO -DCOMMON_RANDOM_FIXED_SEED
+                    -DCOMMON_TIMING_OLD -DSCOTCH_RENAME
+                    -DCOMMON_FILE_COMPRESS_BZ2 -DCOMMON_FILE_COMPRESS_GZ]
+      ldflags  = %w[-lm -lz -lpthread -lbz2]
+
+      cflags  += %w[-DCOMMON_FILE_COMPRESS_LZMA]   if build.with? "xz"
+      ldflags += %W[-L#{Formula["xz"].lib} -llzma] if build.with? "xz"
+
+      make_args = ["CCS=#{ENV["CC"]}",
+                   "CCP=#{ENV["MPICC"]}",
+                   "CCD=#{ENV["MPICC"]}",
+                   "RANLIB=echo",
+                   "CFLAGS=#{cflags.join(" ")}",
+                   "LDFLAGS=#{ldflags.join(" ")}"]
+
+      make_args << "LIB=.dylib"
+      make_args << "AR=libtool"
+      arflags = ldflags.join(" ") + " -dynamic -install_name #{lib}/$(notdir $@) -undefined dynamic_lookup -o"
+      make_args << "ARFLAGS=#{arflags}"
+
+      system "make", "scotch", "VERBOSE=ON", *make_args
+      system "make", "ptscotch", "VERBOSE=ON", *make_args
+      system "make", "install", "prefix=#{prefix}", *make_args
+      system "make", "check", "ptcheck", "EXECP=mpirun -np 2", *make_args if build.with? "test"
+    end
+
+    # Install documentation + sample graphs and grids.
+    doc.install Dir["doc/*.pdf"]
+    pkgshare.install Dir["doc/*.f"], Dir["doc/*.txt"]
+    pkgshare.install "grf", "tgt"
+  end
+
+  test do
+    mktemp do
+      system "echo cmplt 7 | #{bin}/gmap #{pkgshare}/grf/bump.grf.gz - bump.map"
+      system "#{bin}/gmk_m2 32 32 | #{bin}/gmap - #{pkgshare}/tgt/h8.tgt brol.map"
+      system "#{bin}/gout", "-Mn", "-Oi", "#{pkgshare}/grf/4elt.grf.gz", "#{pkgshare}/grf/4elt.xyz.gz", "-", "graph.iv"
+    end
+  end
+end


### PR DESCRIPTION
These formulae should be eventually moved to homebrew-core.