### PR TITLE
mumps 5.1.2

### DIFF
--- a/Formula/mumps.rb
+++ b/Formula/mumps.rb
@@ -1,10 +1,9 @@
 class Mumps < Formula
   desc "Parallel Sparse Direct Solver"
   homepage "http://mumps-solver.org"
-  url "http://mumps.enseeiht.fr/MUMPS_5.1.1.tar.gz"
-  mirror "http://graal.ens-lyon.fr/MUMPS/MUMPS_5.1.1.tar.gz"
-  sha256 "a2a1f89c470f2b66e9982953cbd047d429a002fab9975400cef7190d01084a06"
-  revision 1
+  url "http://mumps.enseeiht.fr/MUMPS_5.1.2.tar.gz"
+  mirror "http://graal.ens-lyon.fr/MUMPS/MUMPS_5.1.2.tar.gz"
+  sha256 "eb345cda145da9aea01b851d17e54e7eef08e16bfa148100ac1f7f046cd42ae9"
 
   bottle :disable, "needs to be rebuilt with latest open-mpi"
 


### PR DESCRIPTION
[Changes from 5.1.1 to 5.1.2](http://mumps.enseeiht.fr/index.php?page=dwnld):
* Corrected an overestimation of memory (regression from 5.1.0)
* Corrected/extended WORKAROUNDINTELILP64MPI2INTEGER mechanism (see INSTALL)
* Parallel analysis: fixed a bug, limited number of MPI processes on small problems, and reverted to sequential analysis on tiny problems. This is to avoid erroneous behavior and failures in the parallel ordering tools.
* Faster BLR clustering on matrices with quasi-dense rows (which are skipped)
* Improved performance of solve phase on very small matrices
* Solve phase with a single MPI process is more thread-safe
* Fixed compilation issue with opensolaris ([SDCZ]MUMPS_TRUNCATED_RRQR)
* Fixed minor bug in BLR factorization (uninitialized timer)
* Corrected minor compiler warnings
* Minor correction to userguide
* Add -DBLR_MT in Intel example Makefile